### PR TITLE
Include "lib" in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": ""
   },
   "files": [
-    "dist"
+    "dist",
+    "lib"
   ],
   "main": "lib/index.js",
   "repository": "dooly-ai/draft-js-typeahead",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from 'React';
+import React from 'react';
 import { Editor, EditorState } from 'draft-js';
 
 function normalizeSelectedIndex(selectedIndex, max) {


### PR DESCRIPTION
`"include": ["dist"]` is set in `package.json`. That means that lib is not included in the npm package.
Also, `entry` is `"lib/index.js"`. This leads to not being able to require the npm package.

For example:

`$ npm install draft-js-typeahead`
```js
const Typeahead = require('draft-js-typeahead');
```

```
> Cannot resolve module "draft-js-typeahead"
```

Just setting `entry` to `dist/draft-typeahead.min.js` does not work either in a non-browser-environment. (`React is not defined`).

I'm submitting a PR to include `lib`folder in the npm package as well.
This resolves the issue and is perfectly acceptable (`react` package does it as well). Also results in better stack traces than when you require a minified version.

Thanks for your great work!

Cheers,
Jonny


----
Edit: I also fixed the following line:
```diff
-import React from 'React'
+import React from 'react'
```

This eliminates a bunch of webpack warnings (and fixes potential Linux issues, not sure)