### PR TITLE
Fix dependencies

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,7 +8,9 @@ const buildDist = (opts) => {
   const webpackOpts = {
     debug: opts.debug,
     externals: {
-      React: 'React',
+      'immutable': 'Immutable',
+      'react': 'React',
+      'react-dom': 'ReactDOM',
       'draft-js': 'Draft'
     },
     output: {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "run-sequence": "^1.1.5",
     "webpack-stream": "^3.1.0"
   },
-  "dependencies": {
-    "draft-js": "^0.8.1",
-    "immutable": "^3.7.6",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+  "peerDependencies": {
+    "draft-js": ">=0.8.1",
+    "immutable": ">=3.7.6",
+    "react": ">=0.14.7",
+    "react-dom": ">=0.14.7"
   }
 }


### PR DESCRIPTION
Currently trying to use this library will result in the error seen below.

```
Uncaught Error: Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).
```

Can read more [here](https://gist.github.com/jimfb/4faa6cbfb1ef476bd105).

Dependencies on React, DraftJS or their peer dependencies should be defined as `"peerDependencies"` in `package.json` otherwise you will end up with duplicate instances where semver is not precise enough (rare).

It should be up to the consumer to define versions of these dependencies as they see fit.